### PR TITLE
Validação de campos year e bibtexkey na inserção de item bibliográfico

### DIFF
--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1095,11 +1095,29 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
                 // Make sure the key is legal:
                 String cleaned = LabelPatternUtil.checkLegalKey(newValue);
+                boolean keyIsValid = false;
                 if ((cleaned == null) || cleaned.equals(newValue)) {
-                    textField.setValidBackgroundColor();
+                    // Checking if the key has at least 2 characters
+                    if (newValue.length() < 2) {
+                        JOptionPane.showMessageDialog(frame,
+                                Localization.lang("BibTeX key must have at least 2 characters"),
+                                Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);
+                    }
+                    // Checking if the first character is a letter
+                    else if (!Character.isLetter(newValue.charAt(0))) {
+                        JOptionPane.showMessageDialog(frame,
+                                Localization.lang("BibTeX key must have a letter in the first position."),
+                                Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);
+                    } else {
+                        keyIsValid = true;
+                        textField.setValidBackgroundColor();
+                    }
                 } else {
                     JOptionPane.showMessageDialog(frame, Localization.lang("Invalid BibTeX key"),
                             Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);
+                }
+
+                if (keyIsValid == false) {
                     textField.setInvalidBackgroundColor();
                     return;
                 }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -132,6 +132,20 @@ public class BibEntry implements Cloneable {
     }
 
     /**
+     * Mock function to test, as the verification was made in the gui
+     */
+    public void mockSetCiteKey(String newCiteKey) {
+        // Checking if the key has at least 2 characters
+        if (newCiteKey.length() < 2) {
+            throw new IllegalArgumentException("BibTeX key must have at least 2 characters.");
+        }
+        // Checking if the first character is a letter
+        else if (!Character.isLetter(newCiteKey.charAt(0))) {
+            throw new IllegalArgumentException("BibTeX key must have a letter in the first position.");
+        }
+    }
+
+    /**
      * Returns the cite key AKA citation key AKA BibTeX key, or null if it is not set.
      *
      * Note: this is <emph>not</emph> the internal Id of this entry. The internal Id is always present, whereas the BibTeX key might not be present.

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -373,8 +373,6 @@ public class BibEntry implements Cloneable {
         case "year":
             checkYear(value);
             break;
-        default:
-            throw new IllegalArgumentException("This field doesn't exist");
         }
     }
 

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -352,25 +352,49 @@ public class BibEntry implements Cloneable {
             throw new IllegalArgumentException("The field name '" + name + "' is reserved");
         }
 
-        // Validations for the value in the year fields
-        if (name == "year") {
-            if (value.matches("[0-9]+")) {
-                DateFormat dateFormat = new SimpleDateFormat("yyyy");
-                Date date = new Date();
-                int currentYear = Integer.valueOf(dateFormat.format(date));
-
-                if (currentYear < Integer.parseInt(value)) {
-                    throw new IllegalArgumentException("The value of year is greater than the current year.");
-                }
-            } else {
-                throw new IllegalArgumentException("The value of year is illegal.");
-            }
-        }
+        // Checks if the value is valid
+        // Only checking year currently
+        checkField(name, value);
 
         changed = true;
 
         fields.put(fieldName, value);
         eventBus.post(new FieldChangedEvent(this, fieldName, value));
+    }
+
+    /**
+     * Checks if the entry is valid. Only the year field is implemented.
+     *
+     * @param name  The field to check.
+     * @param value The value to check.
+     */
+    public void checkField(String fieldName, String value) {
+        switch (fieldName) {
+        case "year":
+            checkYear(value);
+            break;
+        default:
+            throw new IllegalArgumentException("This field doesn't exist");
+        }
+    }
+
+    /**
+     * Checks if the year is valid.
+     *
+     * @param value The year to check.
+     */
+    public void checkYear(String value) {
+        if (value.matches("[0-9]+")) {
+            DateFormat dateFormat = new SimpleDateFormat("yyyy");
+            Date date = new Date();
+            int currentYear = Integer.valueOf(dateFormat.format(date));
+
+            if (currentYear < Integer.parseInt(value)) {
+                throw new IllegalArgumentException("The value of year is greater than the current year.");
+            }
+        } else {
+            throw new IllegalArgumentException("The value of year is illegal.");
+        }
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -352,6 +352,21 @@ public class BibEntry implements Cloneable {
             throw new IllegalArgumentException("The field name '" + name + "' is reserved");
         }
 
+        // Validations for the value in the year fields
+        if (name == "year") {
+            if (value.matches("[0-9]+")) {
+                DateFormat dateFormat = new SimpleDateFormat("yyyy");
+                Date date = new Date();
+                int currentYear = Integer.valueOf(dateFormat.format(date));
+
+                if (currentYear < Integer.parseInt(value)) {
+                    throw new IllegalArgumentException("The value of year is greater than the current year.");
+                }
+            } else {
+                throw new IllegalArgumentException("The value of year is illegal.");
+            }
+        }
+
         changed = true;
 
         fields.put(fieldName, value);

--- a/src/main/java/testES2/testBibtexEntry.java
+++ b/src/main/java/testES2/testBibtexEntry.java
@@ -416,7 +416,7 @@ public class testBibtexEntry {
     }
 
     @Test
-    public void testTodosCamposPreenchidosBook() throws IOException {
+    public void testTodosCamposOpcionaisPreenchidosBook() throws IOException {
         StringWriter stringWriter = new StringWriter();
 
         BibEntry entry = new BibEntry("0002", "book");

--- a/src/main/java/testES2/testBibtexEntry.java
+++ b/src/main/java/testES2/testBibtexEntry.java
@@ -8,7 +8,6 @@ import net.sf.jabref.bibtex.BibEntryWriter;
 import net.sf.jabref.exporter.LatexFieldFormatter;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
-
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -447,4 +446,210 @@ public class testBibtexEntry {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testAnoValidoArticle() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "article");
+        entry.setField("year", "2016");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+
+        // @formatter:off
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
+                "  year = {2016}," + Globals.NEWLINE +
+                "}" + Globals.NEWLINE;
+        // @formatter:on
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAnoValidoBook() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "book");
+        entry.setField("year", "2016");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+
+        // @formatter:off
+        String expected = Globals.NEWLINE + "@Book{," + Globals.NEWLINE +
+                "  year = {2016}," + Globals.NEWLINE +
+                "}" + Globals.NEWLINE;
+        // @formatter:on
+
+        assertEquals(expected, actual);
+    }
+
+    // Test works if the year still is 2016
+    @Test(expected = IllegalArgumentException.class)
+    public void testAnoFuturoArticle() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "article");
+        entry.setField("year", "2017");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+    }
+
+    // Test works if the year still is 2016
+    @Test(expected = IllegalArgumentException.class)
+    public void testAnoFuturoBook() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "book");
+        entry.setField("year", "2017");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAnoInvalidoArticle() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "article");
+        entry.setField("year", "-2017");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAnoInvalidoArticleBook() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "book");
+        entry.setField("year", "-2017");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAnoComLetrasArticle() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "article");
+        entry.setField("year", "A2015B");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAnoComLetrasBook() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "article");
+        entry.setField("year", "A2015B");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+    }
+
+    @Test
+    public void testAnoPreenchendoCamposArticle() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "article");
+        //set a required field
+        entry.setField("author", "Alexandre Tutui");
+        entry.setField("year", "2016");
+        //set an optional field
+        entry.setField("volume", "1");
+        entry.setField("number", "1");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+
+        // @formatter:off
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
+                "  author = {Alexandre Tutui}," + Globals.NEWLINE +
+                "  year   = {2016}," + Globals.NEWLINE +
+                "  volume = {1}," + Globals.NEWLINE +
+                "  number = {1}," + Globals.NEWLINE +
+                "}" + Globals.NEWLINE;
+        // @formatter:on
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAnoPreenchendoCamposBook() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("0002", "book");
+        //set a required field
+        entry.setField("author", "Alexandre Jesus");
+        entry.setField("year", "2013");
+        //set an optional field
+        entry.setField("volume", "2");
+        entry.setField("number", "1");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+
+        // @formatter:off
+        String expected = Globals.NEWLINE + "@Book{," + Globals.NEWLINE +
+            "  year   = {2013}," + Globals.NEWLINE +
+            "  author = {Alexandre Jesus}," + Globals.NEWLINE +
+            "  volume = {2}," + Globals.NEWLINE +
+            "  number = {1}," + Globals.NEWLINE +
+            "}" + Globals.NEWLINE;
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testBibtexkeyValida() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("007", "book");
+        entry.setCiteKey("a0");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Book{"
+                          + "a0,"
+                          + Globals.NEWLINE + "}"
+                + Globals.NEWLINE;
+
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBibtexkeyInvalidaNumero() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("057", "book");
+        // Uses a mock function to test, as the verification is
+        // originally made in the gui
+        entry.mockSetCiteKey("12");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBibtexkeyInvalidaTamanho() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry("07", "book");
+        // Uses a mock function to test, as the verification is
+        // originally made in the gui
+        entry.mockSetCiteKey("a");
+    }
 }


### PR DESCRIPTION
Adicionado validação para os anos (número entre 0 e ano atual) e bibtexkeys (pelo menos dois caracteres começando com uma letra) nas entradas, junto com testes para verificar seus funcionamentos. 
